### PR TITLE
Signal use fix

### DIFF
--- a/source/include/dqm4hep/AppTimer.h
+++ b/source/include/dqm4hep/AppTimer.h
@@ -86,7 +86,7 @@ namespace dqm4hep {
       /**
        *  @brief  Get the timeout signal
        */
-      core::Signal<void> &onTimeout();
+      core::Signal<> &onTimeout();
       
       /**
        *  @brief  Start the timer
@@ -111,7 +111,7 @@ namespace dqm4hep {
       /// The timer interval (unit milliseconds)
       std::atomic_uint             m_interval = {0};
       /// The timer timeout signal
-      core::Signal<void>           m_signal = {};
+      core::Signal<>               m_signal = {};
       /// Whether the timer is active
       std::atomic_bool             m_active = {false};
       /// The time point when the timer was started

--- a/source/src/AppTimer.cc
+++ b/source/src/AppTimer.cc
@@ -69,7 +69,7 @@ namespace dqm4hep {
     
     //-------------------------------------------------------------------------------------------------
     
-    core::Signal<void> &AppTimer::onTimeout() {
+    core::Signal<> &AppTimer::onTimeout() {
       return m_signal;
     }
     


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed use of no arg Signal by changing `Signal<void>` to `Signal<>`

ENDRELEASENOTES