### PR TITLE
Add osx build in travis

### DIFF
--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -9,7 +9,12 @@ cd dqm4hep
 mkdir build
 cd build
 
-cmake -DDQM4HEP_USE_MASTER=ON -DDQM4HEP_DOXYGEN_DOC=OFF -DDQM4HEP_TESTING=ON -DDQM4HEP_WARNING_AS_ERROR=ON -DDQM4HEP_DEV_WARNINGS=ON -DDQMOnline_repository=$TRAVIS_BUILD_DIR -DDQMOnline_version=$TRAVIS_COMMIT ..
+# Disable autamatic testing within make on osx. See comment below
+if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then export DQM4HEP_TESTING="OFF";
+else export DQM4HEP_TESTING="ON";
+fi
+
+cmake -DDQM4HEP_USE_MASTER=ON -DDQM4HEP_DOXYGEN_DOC=OFF -DDQM4HEP_TESTING=$DQM4HEP_TESTING -DDQM4HEP_WARNING_AS_ERROR=ON -DDQM4HEP_DEV_WARNINGS=ON -DDQMOnline_repository=$TRAVIS_BUILD_DIR -DDQMOnline_version=$TRAVIS_COMMIT ..
 
 if [ $? -ne 0 ]; then
     echo "Failed to run cmake"
@@ -21,4 +26,16 @@ make install VERBOSE=1
 if [ $? -ne 0 ]; then
     echo "Failed to run make"
     exit 1
+fi
+
+# For some reason, running ctest from within make leads to an instantaneous Child aborted exception being thrown on osx. Running the tests manually works without trouble though...
+if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+    cd DQMOnline-prefix/src/DQMOnline-build/
+    ctest -V
+
+    if [ $? -ne 0 ]; then
+        echo "Failed to run cmake tests"
+        exit 1
+    fi
+    cd -
 fi

--- a/.travis-ci.d/install_dependencies.sh
+++ b/.travis-ci.d/install_dependencies.sh
@@ -4,8 +4,15 @@ ls -la
 mkdir -p dependencies && cd dependencies
 
 # install root
-wget https://root.cern.ch/download/root_v6.10.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
-tar -xf root_v6.10.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
+if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then export ROOT_BUILD="Linux-ubuntu14-x86_64-gcc4.8";
+elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then export ROOT_BUILD="macosx64-";
+    if [[ "${TRAVIS_OSX_IMAGE}" == "xcode8.3" ]]; then export ROOT_BUILD=$ROOT_BUILD"10.12-clang81";
+    elif [[ "${TRAVIS_OSX_IMAGE}" == "xcode9.3" ]]; then export ROOT_BUILD=$ROOT_BUILD"10.13-clang90";
+    fi;
+fi
+export ROOT_BIN="root_v${ROOT_VERSION}.${ROOT_BUILD}.tar.gz"
+wget https://root.cern.ch/download/${ROOT_BIN}
+tar -xf ${ROOT_BIN}
 source root/bin/thisroot.sh
 root-config --version
 cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,29 @@
 language: cpp
 dist: trusty
 sudo: required
-os:
-  - linux
+
+env:
+  - ROOT_VERSION=6.10.08
+
+os: linux
+compiler:
+  - gcc
+  - clang
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - os: osx
+  include:
+    - os: osx
+      compiler: clang
+      osx_image: xcode8.3 # default, osx 10.12
+    - os: osx
+      compiler: clang
+      osx_image: xcode9.3 # osx 10.13
 
 addons:
   apt:
-    update: true
     sources:
       - ubuntu-toolchain-r-test
     packages:
@@ -15,18 +32,19 @@ addons:
       - g++-4.9
 
 script:
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" && "${CXX}" == "g++"  ]];
+    then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90;
+    fi
   - ./.travis-ci.d/compile_and_test.sh
 
 before_install:
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
   - ./.travis-ci.d/install_dependencies.sh
+  - if [[ "${TRAVIS_OS_NAME}" == "osx"  ]];
+    then brew install mysql;
+    fi
 
 after_success:
   - ./.travis-ci.d/deploy-doxygen.sh
-
-compiler:
-  - gcc
-  - clang
 
 # Don't send e-mail notifications
 notifications:


### PR DESCRIPTION
BEGINRELEASENOTES
- Add osx build in travis, see https://github.com/DQM4HEP/dqm4hep-core/pull/56 for more details
  - Disable auto running of ctests from make as it fails with a `Child aborted` exception
  - Manually run the ctests at the end of the build

ENDRELEASENOTES