### PR TITLE
Fix deprecated Signal method calls

### DIFF
--- a/source/src/AppEventLoop.cc
+++ b/source/src/AppEventLoop.cc
@@ -168,7 +168,7 @@ namespace dqm4hep {
       try
       {
         std::lock_guard<std::recursive_mutex> lock(m_eventMutex);
-        m_onEventSignal.process(pAppEvent);
+        m_onEventSignal.emit(pAppEvent);
       }
       catch(core::StatusCodeException &except)
       {
@@ -181,7 +181,7 @@ namespace dqm4hep {
         }
         else
         {
-          m_onExceptionSignal.process(pAppEvent);
+          m_onExceptionSignal.emit(pAppEvent);
         }
       }
       catch(std::exception &except)
@@ -195,7 +195,7 @@ namespace dqm4hep {
         }
         else
         {
-          m_onExceptionSignal.process(pAppEvent);
+          m_onExceptionSignal.emit(pAppEvent);
         }
       }
       catch(...)
@@ -209,7 +209,7 @@ namespace dqm4hep {
         }
         else
         {
-          m_onExceptionSignal.process(pAppEvent);
+          m_onExceptionSignal.emit(pAppEvent);
         }
       }
       
@@ -253,7 +253,7 @@ namespace dqm4hep {
               if(timeoutReached) {
                 // process timer timeout in event loop
                 processFunction([timer](){
-                  timer->m_signal.process();
+                  timer->m_signal.emit();
                 });
                 // stop it if single shot
                 if(timer->singleShot()) {

--- a/source/src/Application.cc
+++ b/source/src/Application.cc
@@ -272,7 +272,7 @@ namespace dqm4hep {
         dqm_info( "Exiting event loop ..." );
         m_eventLoop.disconnectOnEvent(this);
         if(not noServer()){
-          m_server->onClientExit().disconnectAll();          
+          m_server->onClientExit().disconnect();          
         }
         this->onStop();
       }
@@ -495,7 +495,7 @@ namespace dqm4hep {
     
     void Application::NetworkHandler::sendServiceContent(const net::Buffer &buffer) {
       m_eventLoop.processFunction([&](){
-        m_sendContentSignal.process(buffer);
+        m_sendContentSignal.emit(buffer);
       });
     }
     
@@ -503,7 +503,7 @@ namespace dqm4hep {
     
     void Application::NetworkHandler::sendRequestEvent(const net::Buffer &request, net::Buffer &response) {
       m_eventLoop.processFunction([&](){
-        m_sendRequestSignal.process(request, response);
+        m_sendRequestSignal.emit(request, response);
       });
     }
     
@@ -540,7 +540,7 @@ namespace dqm4hep {
 
     void Application::NetworkHandler::sendCommandEvent(const net::Buffer &buffer) {
       m_eventLoop.processFunction([&](){
-        m_sendContentSignal.process(buffer);
+        m_sendContentSignal.emit(buffer);
       });
     }
     

--- a/source/src/EventCollectorClient.cc
+++ b/source/src/EventCollectorClient.cc
@@ -36,7 +36,7 @@ namespace dqm4hep {
     
     void EventCollectorClient::SourceInfo::receiveEvent(const net::Buffer &buffer) {
       core::EventPtr event = m_collectorClient->readEvent(buffer);
-      m_eventUpdateSignal.process(event);
+      m_eventUpdateSignal.emit(event);
     }
     
     //-------------------------------------------------------------------------------------------------

--- a/source/src/RunControl.cc
+++ b/source/src/RunControl.cc
@@ -80,7 +80,7 @@ namespace dqm4hep {
 
       m_run = run;
       m_running = true;
-      m_sorSignal.process(m_run);
+      m_sorSignal.emit(m_run);
       return STATUS_CODE_SUCCESS;
     }
 
@@ -98,7 +98,7 @@ namespace dqm4hep {
       for(auto &parameter : parameters)
         m_run.setParameter(parameter.first, parameter.second);
         
-      m_sorSignal.process(m_run);
+      m_sorSignal.emit(m_run);
       m_running = true;
       return STATUS_CODE_SUCCESS;
     }
@@ -115,7 +115,7 @@ namespace dqm4hep {
       for(auto &parameter : parameters)
         m_run.setParameter(parameter.first, parameter.second);
 
-      m_eorSignal.process(m_run);
+      m_eorSignal.emit(m_run);
       m_running = false;
       m_run.reset();
       return STATUS_CODE_SUCCESS;


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed deprecated call of `Signal::disconnectAll()` and `Signal::process()`

ENDRELEASENOTES