### PR TITLE
Fix cpu stat reporting

### DIFF
--- a/source/include/dqm4hep/Application.h
+++ b/source/include/dqm4hep/Application.h
@@ -515,7 +515,7 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
     
     template <typename T>
-    void Application::sendStat(const std::string &entryName, const T &stats){
+    inline void Application::sendStat(const std::string &entryName, const T &stats){
       if(not statsEnabled() or noServer()) {
         return;
       }

--- a/source/src/Application.cc
+++ b/source/src/Application.cc
@@ -27,7 +27,6 @@
 
 // -- dqm4hep headers
 #include "dqm4hep/Application.h"
-#include "dqm4hep/OnlineRoutes.h"
 #include "dqm4hep/RemoteLogger.h"
 #include "dqm4hep/Logging.h"
 
@@ -125,25 +124,6 @@ namespace dqm4hep {
       };
       
       dqm_debug( "Creating stat entry '{0}' (unit {1}): {2}", entryName, unit, description );
-    }
-  
-    //-------------------------------------------------------------------------------------------------
-
-    void Application::sendStat(const std::string &entryName, double stats) {
-      if(not statsEnabled() or noServer()) {
-        return;
-      }
-      core::json object = m_statistics[entryName];
-      if(object.is_null())
-        throw core::StatusCodeException(core::STATUS_CODE_NOT_FOUND);
-      // add metadata on the fly
-      object["name"] = entryName;
-      object["value"] = stats;
-      object["appType"] = this->type();
-      object["appName"] = this->name();
-      object["time"] = core::TimePoint::clock::to_time_t(core::now());
-      dqm_debug( "Sending app stat : \n'{0}'", object.dump() );
-      m_client.sendCommand(OnlineRoutes::OnlineManager::appStats(), object.dump());
     }
 
     //-------------------------------------------------------------------------------------------------    

--- a/source/src/Application.cc
+++ b/source/src/Application.cc
@@ -381,6 +381,11 @@ namespace dqm4hep {
       sendStat("CpuSys", m_stats.cpuSys);
       sendStat("CpuTotal", m_stats.cpuTot);
 
+      auto tm_time = localtime(&m_stats.lastPollTime.tv_sec);
+      char date_buf[100];
+      std::strftime(date_buf, sizeof(date_buf), "%Y-%m-%d %H:%M:%S", tm_time);
+
+      sendStat("LastUpdate", date_buf );
       dqm_debug( "Sending internal app stats ... OK" );
     }
     

--- a/source/src/Application.cc
+++ b/source/src/Application.cc
@@ -394,13 +394,13 @@ namespace dqm4hep {
     void Application::createInternalStats() {
       // Virtual memory
       createStatsEntry("VmProc", "Mo", "The current virtual memory in use by the application (unit Mo)");
-      createStatsEntry("VmTotal", "%", "The current virtual memory percentage in use by the application compare to the total available on the host (unit %)");
-      createStatsEntry("VmInUse", "%", "The current virtual memory percentage in use by the application compare to the total used by the running processes (unit %)");
+      createStatsEntry("VmTotal", "%", "The current virtual memory percentage in use by the application compared to the total available on the host (unit %)");
+      createStatsEntry("VmInUse", "%", "The current virtual memory percentage in use by the application compared to the total used by the running processes (unit %)");
       
       // Resident set size
       createStatsEntry("RSSProc", "Mo", "The current resident set size memory in use by the application (unit Mo)");
-      createStatsEntry("RSSTotal", "%", "The current resident set size memory percentage in use by the application compare to the total available on the host (unit %)");
-      createStatsEntry("RSSInUse", "%", "The current resident set size memory percentage in use by the application compare to the total used by the running processes (unit %)");
+      createStatsEntry("RSSTotal", "%", "The current resident set size memory percentage in use by the application compared to the total available on the host (unit %)");
+      createStatsEntry("RSSInUse", "%", "The current resident set size memory percentage in use by the application compared to the total used by the running processes (unit %)");
 
       // Cpu
       createStatsEntry("CpuUser", "%", "The current user cpu load of the application (unit %)");

--- a/source/src/Application.cc
+++ b/source/src/Application.cc
@@ -397,9 +397,9 @@ namespace dqm4hep {
       sendStat("RSSTotal", (procRss/(memInfo.rssTot*1.))*100.);
       sendStat("RSSInUse", (procRss/(memInfo.rssUsed*1.))*100.);
 
-      sendStat("CpuUser", procRss);
-      sendStat("CpuSys", (procRss/(memInfo.rssTot*1.))*100.);
-      sendStat("CpuTotal", (procRss/(memInfo.rssUsed*1.))*100.);
+      sendStat("CpuUser", m_stats.cpuUser);
+      sendStat("CpuSys", m_stats.cpuSys);
+      sendStat("CpuTotal", m_stats.cpuTot);
 
       dqm_debug( "Sending internal app stats ... OK" );
     }

--- a/tests/test-analysis-module.xml
+++ b/tests/test-analysis-module.xml
@@ -2,7 +2,7 @@
   
   <!-- Application settings -->
   <settings mode="EventReader">
-    <parameter name="EnableStatistics"> false </parameter>
+    <parameter name="EnableStatistics"> true </parameter>
     <parameter name="EventReader"> GenericEventXMLReader </parameter>
     <parameter name="EventFileName"> /home/$ENV{USER}/soft/dqm4hep-core/tests/genevt_dummy_data.xml </parameter>
     <parameter name="CyclePeriod"> 1 </parameter>


### PR DESCRIPTION
BEGINRELEASENOTES
  - Cpu stats were reporting mem usage...
  - Make `sendStat` function a template so we can report more than double
  - Fix `LastPollTime` entry to report the date properly formatted instead of a double
ENDRELEASENOTES

@rete  should we change `object["time"] = core::TimePoint::clock::to_time_t(core::now());` to also report a proper date instead of a double?
Otherwise it's getting reported as `"time":1529410315"` instead of `"2018-06-19 14:44:06"`